### PR TITLE
Update dogstatsd-ruby to 3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    datadog-notifications (0.4.7)
+    datadog-notifications (0.4.8)
       activesupport
-      dogstatsd-ruby (~> 3.0.0)
+      dogstatsd-ruby (~> 3.1)
 
 GEM
   remote: https://rubygems.org/
@@ -31,7 +31,7 @@ GEM
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.3)
-    dogstatsd-ruby (3.0.0)
+    dogstatsd-ruby (3.1.0)
     equalizer (0.0.11)
     grape (1.0.0)
       activesupport
@@ -89,4 +89,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.15.3
+   1.16.0

--- a/datadog-notifications.gemspec
+++ b/datadog-notifications.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency(%q<activesupport>)
-  s.add_runtime_dependency(%q<dogstatsd-ruby>, "~> 3.0.0")
+  s.add_runtime_dependency(%q<dogstatsd-ruby>, "~> 3.1")
 
   s.add_development_dependency(%q<rack-test>)
   s.add_development_dependency(%q<grape>, ">= 0.16")

--- a/lib/datadog/notifications/version.rb
+++ b/lib/datadog/notifications/version.rb
@@ -1,5 +1,5 @@
 module Datadog
   class Notifications
-    VERSION = "0.4.7"
+    VERSION = "0.4.8"
   end
 end


### PR DESCRIPTION
We would like to have the dependency dogstatsd-ruby to use the latest version 3.1.0 in order to get the unix socket support.