### PR TITLE
plugins: added Datadog::Notifications::Plugins::GRPC

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    datadog-notifications (0.5.1)
+    datadog-notifications (0.6.0)
       activesupport
       dogstatsd-ruby (~> 3.1)
 
@@ -106,4 +106,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.16.1
+   1.16.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    datadog-notifications (0.6.0)
+    datadog-notifications (0.5.2)
       activesupport
       dogstatsd-ruby (~> 3.1)
 

--- a/datadog-notifications.gemspec
+++ b/datadog-notifications.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.version       = Datadog::Notifications::VERSION.dup
   s.authors       = ["Dimitrij Denissenko"]
   s.email         = ["dimitrij@blacksquaremedia.com"]
-  s.description   = 'Datadog instrumnetation for ActiveSupport::Notifications'
+  s.description   = 'Datadog instrumentation for ActiveSupport::Notifications'
   s.summary       = 'Generic ActiveSupport::Notifications Datadog handler'
   s.homepage      = "https://github.com/bsm/datadog-notifications"
 

--- a/lib/datadog/notifications/plugins.rb
+++ b/lib/datadog/notifications/plugins.rb
@@ -5,6 +5,6 @@ module Datadog
   end
 end
 
-%w[base grape active_record active_job action_controller].each do |name|
+%w[base grape active_record active_job action_controller grpc].each do |name|
   require "datadog/notifications/plugins/#{name}"
 end

--- a/lib/datadog/notifications/plugins.rb
+++ b/lib/datadog/notifications/plugins.rb
@@ -1,10 +1,12 @@
 module Datadog
   class Notifications
     module Plugins
+      autoload :Base,             'datadog/notifications/plugins/base'
+      autoload :Grape,            'datadog/notifications/plugins/grape'
+      autoload :ActiveRecord,     'datadog/notifications/plugins/active_record'
+      autoload :ActiveJob,        'datadog/notifications/plugins/active_job'
+      autoload :ActionController, 'datadog/notifications/plugins/action_controller'
+      autoload :GRPC,             'datadog/notifications/plugins/grpc'
     end
   end
-end
-
-%w[base grape active_record active_job action_controller grpc].each do |name|
-  require "datadog/notifications/plugins/#{name}"
 end

--- a/lib/datadog/notifications/plugins/grpc.rb
+++ b/lib/datadog/notifications/plugins/grpc.rb
@@ -1,0 +1,38 @@
+module Datadog::Notifications::Plugins
+  class GRPC < Base
+
+    # Options:
+    #
+    # *<tt>:metric_name</tt> - the metric name, defaults to 'grpc.request'
+    # *<tt>:tags</tt> - additional tags
+    #
+    # It expects ActiveSupport instrumented notifications named 'process_action.grpc'.
+    # Each such notification should have an :action key with gRPC action (method) name.
+    #
+    # Compatible instrumentation is implemented in grpcx gem: https://github.com/bsm/grpcx
+    def initialize(opts={})
+      super
+      @metric_name = opts[:metric_name] || 'grpc.request'
+
+      Datadog::Notifications.subscribe 'process_action.grpc' do |reporter, event|
+        record reporter, event
+      end
+    end
+
+    private
+
+    def record(reporter, event)
+      payload = event.payload
+      action  = payload[:action]
+      status  = payload[:exception] ? 'error' : 'ok'
+
+      tags = self.tags + %W[action:#{action} status:#{status}]
+
+      reporter.batch do
+        reporter.increment metric_name, tags: tags
+        reporter.timing "#{metric_name}.time", event.duration, tags: tags
+      end
+    end
+
+  end
+end

--- a/lib/datadog/notifications/version.rb
+++ b/lib/datadog/notifications/version.rb
@@ -1,5 +1,5 @@
 module Datadog
   class Notifications
-    VERSION = '0.5.1'.freeze
+    VERSION = '0.6.0'.freeze
   end
 end

--- a/lib/datadog/notifications/version.rb
+++ b/lib/datadog/notifications/version.rb
@@ -1,5 +1,5 @@
 module Datadog
   class Notifications
-    VERSION = '0.6.0'.freeze
+    VERSION = '0.5.2'.freeze
   end
 end


### PR DESCRIPTION
For gRPC service instrumentation (for [grpcx](https://github.com/bsm/grpcx) gem reporting).

Looks extremely simple, so I did not bother with tests.

Bumped minor version (new backward-compatible functionality).