### PR TITLE
plugins/grpc: accept :service/:action payload (as grpcx >= 0.2.0 sends)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    datadog-notifications (0.5.3)
+    datadog-notifications (0.6.0)
       activesupport
       dogstatsd-ruby (~> 3.1)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    datadog-notifications (0.6.0)
+    datadog-notifications (0.5.4)
       activesupport
       dogstatsd-ruby (~> 3.1)
 

--- a/datadog-notifications.gemspec
+++ b/datadog-notifications.gemspec
@@ -3,24 +3,24 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'datadog/notifications/version'
 
 Gem::Specification.new do |s|
-  s.name          = "datadog-notifications"
+  s.name          = 'datadog-notifications'
   s.version       = Datadog::Notifications::VERSION.dup
-  s.authors       = ["Dimitrij Denissenko"]
-  s.email         = ["dimitrij@blacksquaremedia.com"]
+  s.authors       = ['Dimitrij Denissenko']
+  s.email         = ['dimitrij@blacksquaremedia.com']
   s.description   = 'Datadog instrumentation for ActiveSupport::Notifications'
   s.summary       = 'Generic ActiveSupport::Notifications Datadog handler'
-  s.homepage      = "https://github.com/bsm/datadog-notifications"
+  s.homepage      = 'https://github.com/bsm/datadog-notifications'
 
   s.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   s.test_files    = s.files.grep(%r{^(spec)/})
-  s.require_paths = ["lib"]
+  s.require_paths = ['lib']
 
   s.add_runtime_dependency('activesupport')
-  s.add_runtime_dependency('dogstatsd-ruby', "~> 3.1")
+  s.add_runtime_dependency('dogstatsd-ruby', '~> 3.1')
 
   s.add_development_dependency('activerecord')
   s.add_development_dependency('bundler')
-  s.add_development_dependency('grape', ">= 0.16")
+  s.add_development_dependency('grape', '>= 0.16')
   s.add_development_dependency('rack-test')
   s.add_development_dependency('rake')
   s.add_development_dependency('rspec')

--- a/lib/datadog/notifications/plugins/grpc.rb
+++ b/lib/datadog/notifications/plugins/grpc.rb
@@ -7,9 +7,9 @@ module Datadog::Notifications::Plugins
     # *<tt>:tags</tt> - additional tags
     #
     # It expects ActiveSupport instrumented notifications named 'process_action.grpc'.
-    # Each such notification should have an :action key with gRPC action (method) name.
+    # Notification payload should have :service (service name, string) and :action (service action/method name, string) keys.
     #
-    # Compatible instrumentation is implemented in grpcx gem: https://github.com/bsm/grpcx
+    # Compatible instrumentation is implemented in grpcx gem: https://github.com/bsm/grpcx (>= 0.2.0)
     def initialize(opts={})
       super
       @metric_name = opts[:metric_name] || 'grpc.request'
@@ -23,10 +23,11 @@ module Datadog::Notifications::Plugins
 
     def record(reporter, event)
       payload = event.payload
+      service = payload[:service]
       action  = payload[:action]
       status  = payload[:exception] ? 'error' : 'ok'
 
-      tags = self.tags + %W[action:#{action} status:#{status}]
+      tags = self.tags + %W[service:#{service} action:#{action} status:#{status}]
 
       reporter.batch do
         reporter.increment @metric_name, tags: tags

--- a/lib/datadog/notifications/version.rb
+++ b/lib/datadog/notifications/version.rb
@@ -1,5 +1,5 @@
 module Datadog
   class Notifications
-    VERSION = '0.6.0'.freeze
+    VERSION = '0.5.4'.freeze
   end
 end

--- a/lib/datadog/notifications/version.rb
+++ b/lib/datadog/notifications/version.rb
@@ -1,5 +1,5 @@
 module Datadog
   class Notifications
-    VERSION = '0.5.3'.freeze
+    VERSION = '0.6.0'.freeze
   end
 end


### PR DESCRIPTION
As implemented in grpcx 0.2.0: https://github.com/bsm/grpcx/pull/6

Post-merge:
- [x] update [grpcx/README.md](https://github.com/bsm/grpcx#using-with-datadognotifications) usage: https://github.com/bsm/grpcx/pull/7